### PR TITLE
cast numpy.float32 to float before serializing data with simplejson

### DIFF
--- a/scripts/tSNE-images.py
+++ b/scripts/tSNE-images.py
@@ -63,7 +63,7 @@ def run_tsne(images_path, output_path, tsne_dimensions, tsne_perplexity, tsne_le
     # save data to json
     data = []
     for i,f in enumerate(images):
-        point = [ (tsne[i,k] - np.min(tsne[:,k]))/(np.max(tsne[:,k]) - np.min(tsne[:,k])) for k in range(tsne_dimensions) ]
+        point = [float((tsne[i,k] - np.min(tsne[:,k]))/(np.max(tsne[:,k]) - np.min(tsne[:,k]))) for k in range(tsne_dimensions) ]
         data.append({"path":os.path.abspath(join(images_path,images[i])), "point":point})
     with open(output_path, 'w') as outfile:
         json.dump(data, outfile)


### PR DESCRIPTION
Passing a `<class 'numpy.float32'>` to `simplejson.dump` results in a `TypeError: 0.61730546 is not JSON serializable`

This fix casts the numpy.float32 to a python float which can be serialized.