### PR TITLE
Fix url to the complete guide, it was given a 404

### DIFF
--- a/apps/Gobot/README.md
+++ b/apps/Gobot/README.md
@@ -1,6 +1,6 @@
 ## Gobot
 
-[A complete guide to this application can be found here](http://ml4a.github.io/guides/GoBot/)
+[A complete guide to this application can be found here](http://ml4a.github.io/guides/Gobot/)
 
 To build from source, the following addons are required:
 - [ofxDarknet](https://github.com/mrzl/ofxDarknet)


### PR DESCRIPTION
Just looking through your site, and I play Go so I checked out the Github, and noticed the link doesn't work, so this fixes it.